### PR TITLE
feat: add GitHub action for update license year

### DIFF
--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -1,0 +1,19 @@
+name: Update copyright year in license file and license header of all files
+
+#on:
+#  schedule:
+#    - cron: "0 3 1 1 *"
+
+on: workflow_dispatch
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: src/**/*.java


### PR DESCRIPTION
add GitHub action for automatically update license year in LICENCE.txt and license header at 03:00 AM on every January 1